### PR TITLE
[LA.VENDOR.1.0.r1] Remove proprietary libraries

### DIFF
--- a/ipc/HwBinders/agm_ipc_service/Android.mk
+++ b/ipc/HwBinders/agm_ipc_service/Android.mk
@@ -16,7 +16,6 @@ LOCAL_SHARED_LIBRARIES := \
     libcutils \
     libhardware \
     libbase \
-    libar-gsl \
     vendor.qti.hardware.AGMIPC@1.0 \
     libagm
 

--- a/service/Android.mk
+++ b/service/Android.mk
@@ -46,11 +46,8 @@ LOCAL_HEADER_LIBRARIES := \
     libacdb_headers
 
 LOCAL_SHARED_LIBRARIES := \
-    libar-gsl \
     liblog \
-    liblx-osal \
-    libaudioroute \
-    libats
+    libaudioroute 
 
 #if android version is R, use qtitinyalsa lib otherwise use upstream ones
 #This assumes we would be using AR code only for Android R and subsequent versions.
@@ -70,4 +67,3 @@ LOCAL_HEADER_LIBRARIES += libaudiologutils_headers
 endif
 
 include $(BUILD_SHARED_LIBRARY)
-


### PR DESCRIPTION
We do not want these (And cant) while building.

These will be included in ODM as blobs and loaded
on runtime.

Signed-off-by: Martin Botka <martin.botka@somainline.org>