### PR TITLE
[8.0.r1] plugins: tinyalsa: test: Add kvh2xml_headers dependency

### DIFF
--- a/plugins/tinyalsa/test/Android.mk
+++ b/plugins/tinyalsa/test/Android.mk
@@ -11,7 +11,8 @@ LOCAL_SRC_FILES     := agmmixer.c
 
 LOCAL_HEADER_LIBRARIES := \
     libagm_headers \
-    libacdb_headers
+    libacdb_headers \
+    kvh2xml_headers
 
 #if android version is R, refer to qtitinyxx otherwise use upstream ones
 #This assumes we would be using AR code only for Android R and subsequent versions.
@@ -42,7 +43,8 @@ LOCAL_SRC_FILES     := agmplay.c
 
 LOCAL_HEADER_LIBRARIES := \
     libagm_headers \
-    libacdb_headers
+    libacdb_headers \
+    kvh2xml_headers
 
 #if android version is R, refer to qtitinyxx otherwise use upstream ones
 #This assumes we would be using AR code only for Android R and subsequent versions.
@@ -70,7 +72,8 @@ LOCAL_SRC_FILES     := agmcap.c
 
 LOCAL_HEADER_LIBRARIES := \
     libagm_headers \
-    libacdb_headers
+    libacdb_headers \
+    kvh2xml_headers
 
 #if android version is R, refer to qtitinyxx otherwise use upstream ones
 #This assumes we would be using AR code only for Android R and subsequent versions.
@@ -99,7 +102,8 @@ LOCAL_SRC_FILES     := agmhostless.c
 
 LOCAL_HEADER_LIBRARIES := \
     libagm_headers \
-    libacdb_headers
+    libacdb_headers \
+    kvh2xml_headers
 
 #if android version is R, refer to qtitinyxx otherwise use upstream ones
 #This assumes we would be using AR code only for Android R and subsequent versions.
@@ -134,7 +138,8 @@ LOCAL_SRC_FILES     := agmcompressplay.c
 
 LOCAL_HEADER_LIBRARIES := \
     libagm_headers \
-    libacdb_headers
+    libacdb_headers \
+    kvh2xml_headers
 
 # Use flag based selection to use QTI vs open source tinycompress project
 
@@ -171,7 +176,8 @@ LOCAL_SRC_FILES     := agmcompresscap.c
 
 LOCAL_HEADER_LIBRARIES := \
     libagm_headers \
-    libacdb_headers
+    libacdb_headers \
+    kvh2xml_headers
 
 # Use flag based selection to use QTI vs open source tinycompress project
 
@@ -204,7 +210,8 @@ LOCAL_SRC_FILES     := agm_voiceui.c
 
 LOCAL_HEADER_LIBRARIES := \
     libagm_headers \
-    libacdb_headers
+    libacdb_headers \
+    kvh2xml_headers
 
 #if android version is R, refer to qtitinyxx otherwise use upstream ones
 #This assumes we would be using AR code only for Android R and subsequent versions.


### PR DESCRIPTION
agm test apps depend on kvh2xml_headers.