### PR TITLE
[8.0.r1] plugins: tinyalsa: Fix -Wincompatible-function-pointer-types

### DIFF
--- a/plugins/tinyalsa/src/agm_pcm_plugin.c
+++ b/plugins/tinyalsa/src/agm_pcm_plugin.c
@@ -862,21 +862,15 @@ static int agm_pcm_munmap(struct pcm_plugin *plugin, void *addr, size_t length)
     return munmap(addr, length);
 }
 
-static int agm_pcm_ioctl(struct pcm_plugin *plugin, int cmd, ...)
+static int agm_pcm_ioctl(struct pcm_plugin *plugin, int cmd, void *arg __unused)
 {
     struct agm_pcm_priv *priv = plugin->priv;
     uint64_t handle;
     int ret = 0;
-    va_list ap;
-    void *arg;
 
     ret = agm_get_session_handle(priv, &handle);
     if (ret)
         return ret;
-
-    va_start(ap, cmd);
-    arg = va_arg(ap, void *);
-    va_end(ap);
 
     switch (cmd) {
     case SNDRV_PCM_IOCTL_RESET:


### PR DESCRIPTION
```
plugins/tinyalsa/src/agm_pcm_plugin.c:906:14: error: incompatible
function pointer types initializing 'int (*)(struct pcm_plugin *,
int, void *)' with an expression of type 'int (struct pcm_plugin *,
int, ...)' [-Wincompatible-function-pointer-types]
  906 |     .ioctl = agm_pcm_ioctl,
      |              ^~~~~~~~~~~~~
```