### PR TITLE
[8.0.r1] service: graph: Add ability to receive ACDB path in runtime

### DIFF
--- a/service/Android.mk
+++ b/service/Android.mk
@@ -55,6 +55,11 @@ LOCAL_SHARED_LIBRARIES := \
     libaudioroute \
     libats
 
+ifeq ($(strip $(PRODUCT_PLATFORM_SOD)), true)
+LOCAL_CFLAGS           += -DPRODUCT_PLATFORM_SOD
+LOCAL_SHARED_LIBRARIES += libcutils
+endif
+
 #if android version is R, use qtitinyalsa lib otherwise use upstream ones
 #This assumes we would be using AR code only for Android R and subsequent versions.
 ifneq ($(filter R 11,$(PLATFORM_VERSION)),)

--- a/service/src/graph.c
+++ b/service/src/graph.c
@@ -75,6 +75,10 @@
 #include <agm/metadata.h>
 #include <agm/utils.h>
 
+#ifdef PRODUCT_PLATFORM_SOD
+#include <cutils/properties.h>
+#endif
+
 #ifdef DYNAMIC_LOG_ENABLED
 #include <log_xml_parser.h>
 #define LOG_MASK AGM_MOD_FILE_GRAPH
@@ -121,6 +125,50 @@ typedef struct module_info_link_list {
 
 static char acdb_path[ACDB_PATH_MAX_LENGTH];
 static void print_graph_alias(const struct agm_meta_data_gsl *meta_data_kv);
+
+#ifdef PRODUCT_PLATFORM_SOD
+static struct sony_devices {
+    char *device_name;
+    char *codec_name_sysfs;
+};
+
+static struct sony_devices sony_devices_info[] = {
+    { "pdx246", "/sys/bus/i2c/drivers/aw882xx_smartpa/1-0034/chip_name" },
+};
+
+static void get_acdb_files_path(const char *acdb_files_path)
+{
+    char prop[PROPERTY_VALUE_MAX] = {0};
+    char buf[FILE_PATH_EXTN_MAX_SIZE] = {0};
+    FILE *file = NULL;
+    size_t len = 0;
+
+    if (!property_get("ro.product.vendor.device", prop, ""))
+        return;
+
+    for (int i = 0; i < sizeof(sony_devices_info) / sizeof(*sony_devices_info); i++) {
+        if (strcmp(sony_devices_info[i].device_name, prop) == 0) {
+            file = fopen(sony_devices_info[i].codec_name_sysfs, "r");
+            if (file == NULL)
+                return;
+
+            if (fgets(buf, sizeof(buf) - 1, file)) {
+                // Remove newline if it exists
+                len = strlen(buf);
+                if (len > 0 && buf[len - 1] == '\n')
+                    buf[len - 1] = '\0';
+
+                // Check if the buffer is empty or just a newline
+                if (buf[0] != '\0')
+                    snprintf(acdb_files_path, ACDB_PATH_MAX_LENGTH, "%s%s", ACDB_PATH, buf);
+            }
+
+            fclose(file);
+            return;
+        }
+    }
+}
+#endif
 
 static int get_acdb_files_from_directory(const char* acdb_files_path,
                                          struct gsl_acdb_data_files *data_files)
@@ -340,6 +388,16 @@ int graph_init()
         ret = -ENOENT;
         goto err;
     }
+
+#ifdef PRODUCT_PLATFORM_SOD
+    /**
+     * Sometimes acdb_path must be determined at runtime based on the codec name.
+     * The path will only be updated if the codec provides information about
+     * itself and the device is present in the sony_devices_info array.
+     */
+    get_acdb_files_path(acdb_path);
+#endif
+
     AGM_LOGI("acdb file path: %s\n", acdb_path);
 
     ret = get_acdb_files_from_directory(acdb_path, &acdb_files);


### PR DESCRIPTION
Some Sony devices (Xperia 10 VI, PDX246) may potentially
have different models of audio codecs/amplifiers; therefore,
ACDB files are stored in directories named according to the
codec/amplifier model. By default, AGM retrieves ACDB files
from a directory named as platform and its variant, for
example: parrot_qrd_sku1. This approach doesn't fully meet
our needs, so a custom path capability has been implemented
for devices that might require it.
The new get_acdb_files_path() function retrieves the device
model from the ro.product.vendor.device property. If the
model is listed in the sony_devices_info list, it attempts
to get the codec/amplifier model directly from the driver
via sysfs. If the driver returns the name, the path will be
based on this information, for example:
/vendor/etc/acdbdata/AW88263. Otherwise, the function does
nothing, and the default path will be used.

Additionally, this functionality is protected by the
PRODUCT_PLATFORM_SOD flag to prevent unintended use
outside the SODP project.

Happy New Year!